### PR TITLE
fix: id token permissions for cosign

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  id-token: write
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build image and deploy to Kubernetes
 on:
   push:
     branches: [main]
-  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
Cosign needs this to sign the image with the identity of the Github Action Workflow